### PR TITLE
Fix homepage_url in manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "version": "1.3.1",
   "manifest_version": 3,
   "description": "Ethereum gas price info, always up to date, from multiple sources",
-  "homepage_url": "https://github.com/philippe-git/ethereum-gas-price-browser-extension",
+  "homepage_url": "https://github.com/philippe-git/ethereum-gas-prices-browser-extension",
   "permissions": [
     "alarms",
     "storage"


### PR DESCRIPTION
The incorrect URL causes an issue where clicking on the extension takes you to a 404.